### PR TITLE
ConnectionFactory constructor should use class setter methods [Fixes #12]

### DIFF
--- a/src/main/java/io/nats/stan/ConnectionFactory.java
+++ b/src/main/java/io/nats/stan/ConnectionFactory.java
@@ -31,8 +31,8 @@ public class ConnectionFactory {
     public ConnectionFactory() {}
 
     public ConnectionFactory(String clusterId, String clientId) {
-        this.clusterId = clusterId;
-        this.clientId = clientId;
+        setClusterId(clusterId);
+        setClientId(clientId);
     }
 
     public ConnectionImpl createConnection() throws IOException, TimeoutException {

--- a/src/test/java/io/nats/stan/ConnectionImplTest.java
+++ b/src/test/java/io/nats/stan/ConnectionImplTest.java
@@ -265,7 +265,8 @@ public class ConnectionImplTest {
             conn.setPubAckChan(pac);
             assertEquals(conn.getPubAckChan(), pac);
 
-            Map<String, AckClosure> mockMap = mock(Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, AckClosure> mockMap = (Map<String, AckClosure>) mock(Map.class);
             conn.setPubAckMap(mockMap);
             assertEquals(mockMap, conn.getPubAckMap());
         } catch (Exception e) {


### PR DESCRIPTION
Changed `ConnectionFactory(String clusterId, String clientId)` to use the setter methods for the arguments vs directly setting the values.