### PR TITLE
#41 Do not stop timer on the exception thrown by the timer task

### DIFF
--- a/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
+++ b/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
@@ -568,7 +568,6 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
     protected void processAckTimeout(String guid) {
         AckClosure ackClosure = removeAck(guid);
         if (ackClosure == null) {
-            logger.warn("stan: no ack available, could be due to the race condition");
             return;
         }
         if (ackClosure.ah != null) {


### PR DESCRIPTION
Was trying to resolve #41. As discussed with @kozlovic wrapping `processAckTimeout` with `try/catch` should prevent the timer be stopped.

Although by making the corresponding change makes `ITConnectionTest::testRaceAckOnClose` to fail. Which also probably explains the reason why the timer task actually threw an exception (so based on the test name, it is indeed looks like due to the race condition). 

I've also observed (see in the changes made), that in the case of the race condition the returned `ackClosure` was null, and so `NPE` was thrown.

Again, this PR is not ready to be merged, as I don't know how to fix `ITConnectionTest::testRaceAckOnClose`, but maybe it will be a starting point for the maintainers to move it further (and maybe the better fix would be to avoid race condition at all? or use `Executors`?, as I am not yet familiar with the internals of the NATS streaming protocol to feel confident to make the corresponding changes).

@kozlovic @mcqueary any thoughts?