### PR TITLE
made StreamingConnectionFactory class public

### DIFF
--- a/src/main/java/io/nats/streaming/StreamingConnectionFactory.java
+++ b/src/main/java/io/nats/streaming/StreamingConnectionFactory.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
  * A {@code StreamingConnectionFactory} object encapsulates a set of connection configuration
  * options. A client uses it to create a connection to the STAN streaming data system.
  */
-class StreamingConnectionFactory {
+public class StreamingConnectionFactory {
     private Duration ackTimeout = Duration.ofMillis(SubscriptionImpl.DEFAULT_ACK_WAIT);
     private Duration connectTimeout = Duration.ofSeconds(NatsStreaming
             .DEFAULT_CONNECT_WAIT);


### PR DESCRIPTION
I presume that this was supposed to be public, right? The old `ConnectionFactory` class in 4.1 was public...