### PR TITLE
Provided a better message when encountering invalid clusterId

### DIFF
--- a/src/main/java/io/nats/streaming/NatsStreaming.java
+++ b/src/main/java/io/nats/streaming/NatsStreaming.java
@@ -17,6 +17,7 @@ public final class NatsStreaming {
     static final String PFX = "stan: ";
     static final String ERR_CONNECTION_REQ_TIMEOUT = PFX + "connect request timeout";
     static final String ERR_CLOSE_REQ_TIMEOUT = PFX + "close request timeout";
+    static final String ERR_INVALID_CLUSTER_ID = PFX + "invalid clusterId";    
     static final String ERR_SUB_REQ_TIMEOUT = PFX + "subscribe request timeout";
     static final String ERR_UNSUB_REQ_TIMEOUT = PFX + "unsubscribe request timeout";
     static final String ERR_CONNECTION_CLOSED = PFX + "connection closed";

--- a/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
+++ b/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
@@ -124,7 +124,7 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
             Message reply;
             reply = nc.request(discoverSubject, bytes, opts.getConnectTimeout().toMillis());
             if (reply == null) {
-                throw new IOException(ERR_CONNECTION_REQ_TIMEOUT);
+                throw new IOException(ERR_INVALID_CLUSTER_ID);
             }
             ConnectResponse cr = ConnectResponse.parseFrom(reply.getData());
             if (!cr.getError().isEmpty()) {


### PR DESCRIPTION
This PR addresses issue https://github.com/nats-io/java-nats-streaming/issues/70