### PR TITLE
Unsubscribe - nullpointerexception. No data returned newer versions of NATS

### DIFF
--- a/src/main/java/io/nats/streaming/SubscriptionImpl.java
+++ b/src/main/java/io/nats/streaming/SubscriptionImpl.java
@@ -182,9 +182,11 @@ class SubscriptionImpl implements Subscription {
             throw new IOException(e);
         }
 
-        SubscriptionResponse response = SubscriptionResponse.parseFrom(reply.getData());
-        if (!response.getError().isEmpty()) {
-            throw new IOException(PFX + response.getError());
+        if(reply.getData() != null) {
+            SubscriptionResponse response = SubscriptionResponse.parseFrom(reply.getData());
+            if (!response.getError().isEmpty()) {
+                throw new IOException(PFX + response.getError());
+            }
         }
     }
 


### PR DESCRIPTION
…rom nats. In older versions there was data and the code did depend on that.

For now a simple fix.

Issue mentioned in: https://github.com/nats-io/java-nats-streaming/issues/86