### PR TITLE
V2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: java
 sudo: required
 jdk:
 - oraclejdk8
+- oraclejdk9
+- oraclejdk10
+- openjdk8
+- openjdk9
+- openjdk10
 before_script:
 - wget "https://github.com/nats-io/nats-streaming-server/releases/download/$stan_version/nats-streaming-server-$stan_version-linux-amd64.zip"
   -O tmp.zip
@@ -24,7 +29,7 @@ cache:
   - "$HOME/.gradle/wrapper/"
 after_success:
 - "./gradlew test jacocoTestReport coveralls"
-- test ${TRAVIS_BRANCH} != 'master' && "./gradlew uploadArchives" # Disable master for now, it fails due to ip address issues
+- test ${TRAVIS_BRANCH} != 'master' && test ${TRAVIS_JDK_VERSION} == 'oraclejdk8' && "./gradlew uploadArchives" # Disable master for now, it fails due to ip address issues
 #Disable for now, upload archives failes because of IP address changes - "test ${TRAVIS_PULL_REQUEST} != 'true' && test ${TRAVIS_BRANCH} = 'master' && ./gradlew closeAndReleaseRepository"
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Version 2.1.0
+
+* [Added] Added named dispatchers to subscriptions to allow application control of callback threads
+* [#100] Split internal callback dispatchers to prevent application code blocking heartbeats
+
 ## Version 2.0.3
 
 * [#93] Made it easier to set the error and connection listener on a stream connection

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [Java](http://java.com) client for the [NATS streaming platform](https://nats.
 
 ## A Note on Versions
 
-This is version 2.0 of the Java NATS streaming library. This version is a minor port to version 2.0 of the Java NATS library, but contains breaking changes due to the way the underlying library handles exceptions, especially timeouts.
+This is version 2.1 of the Java NATS streaming library. This version is a minor port to version 2.1 of the Java NATS library, but contains breaking changes due to the way the underlying library handles exceptions, especially timeouts.
 
 The new version minimizes threads. Only one thread is used for all callbacks, by relying on a dispatcher in the underlying NATS connection. If you want to deliver in multiple threads, you can use multiple StreamingConnections on the same underlying NATS connection. This reduces total thread usage while allowing callbacks to work independently. See [Sharing A NATS Connection](#sharing-a-nats-connection).
 
@@ -26,9 +26,9 @@ The nats streaming client requires two jar files to run, the java nats library a
 
 ### Downloading the Jar
 
-You can download the latest NATS client jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.0.1/jnats-2.0.1.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.0.1/jnats-2.0.1.jar).
+You can download the latest NATS client jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.1.0/jnats-2.1.0.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.0.1/jnats-2.0.1.jar).
 
-You can download the latest java nats streaming jar at [https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.0.1/java-nats-streaming-2.0.1.jar](https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.0.1/java-nats-streaming-2.0.1.jar).
+You can download the latest java nats streaming jar at [https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.1.0/java-nats-streaming-2.1.0.jar](https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.1.0/java-nats-streaming-2.1.0.jar).
 
 ### Using Gradle
 
@@ -36,7 +36,7 @@ The NATS client is available in the Maven central repository, and can be importe
 
 ```groovy
 dependencies {
-    implementation 'io.nats:java-nats-streaming:2.0.0'
+    implementation 'io.nats:java-nats-streaming:2.1.0'
 }
 ```
 
@@ -62,7 +62,7 @@ The NATS client is available on the Maven central repository, and can be importe
 <dependency>
     <groupId>io.nats</groupId>
     <artifactId>java-nats-streaming</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 
@@ -344,6 +344,16 @@ StreamingConnection two = NatsStreaming.connect(clusterName, clientTwo, streamin
 ```
 
 you have to close `two` before you close `one` to avoid an exception.
+
+### Controlling Callback Threads
+
+The underlying NATS library uses the concept of dispatchers to organize callback threads. You can leverage this feature in 2.1.0 or later of this
+library by setting a dispatcher name on your subscriptions.
+
+```java
+Subscription sub2 = sc.subscribe("foo", mcb2,
+                           new SubscriptionOptions.Builder().deliverAllAvailable().dispatcher("one").build());
+```
 
 ## Building From Source
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ plugins {
 
 // Update version here, repeated check-ins not into master will have snapshot on them
 def versionMajor = 2
-def versionMinor = 0
-def versionPatch = 3
+def versionMinor = 1
+def versionPatch = 0
 def versionModifier = ""
 def branch = System.getenv("TRAVIS_BRANCH");
 

--- a/src/main/java/io/nats/streaming/StreamingConnection.java
+++ b/src/main/java/io/nats/streaming/StreamingConnection.java
@@ -151,7 +151,7 @@ public interface StreamingConnection extends AutoCloseable {
      */
     Subscription subscribe(String subject, String queue, MessageHandler cb,
                            SubscriptionOptions opts) throws IOException, InterruptedException, TimeoutException;
-
+                           
     /**
      * Returns the underlying NATS connection. Use with caution, especially if you didn't create the
      * connection.

--- a/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
+++ b/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
@@ -124,17 +124,11 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
             this.ackSubject = String.format("%s.%s", NatsStreaming.DEFAULT_ACK_PREFIX, this.nuid.next());
 
             this.ackDispatcher = nc.createDispatcher(msg -> {
-                String subject = msg.getSubject();
-                if (this.ackSubject.equals(subject)) {
-                    this.processAck(msg);
-                }
+                this.processAck(msg);
             });
 
             this.heartbeatDispatcher = nc.createDispatcher(msg -> {
-                String subject = msg.getSubject();
-                if(this.hbSubject.equals(subject)) {
-                    this.processHeartBeat(msg);
-                }
+                this.processHeartBeat(msg);
             });
 
             this.messageDispatcher = nc.createDispatcher(msg -> {
@@ -256,12 +250,10 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
                 }
 
                 if (this.ackDispatcher != null && this.ackDispatcher.isActive()) {
-                    this.ackDispatcher.unsubscribe(this.ackSubject);
                     nc.closeDispatcher(this.ackDispatcher);
                 }
 
                 if (this.heartbeatDispatcher != null && this.heartbeatDispatcher.isActive()) {
-                    this.heartbeatDispatcher.unsubscribe(this.hbSubject);
                     nc.closeDispatcher(this.heartbeatDispatcher);
                 }
 

--- a/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
+++ b/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
@@ -402,10 +402,14 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
         return guid;
     }
 
-    Dispatcher getCustomDispatcher(String name) {
+    Dispatcher getDispatcherByName(String name) {
         Dispatcher d = null;
         this.lock();
         try {
+            if (name == null || name.isEmpty()) {
+                return this.messageDispatcher;
+            }
+
             d = customDispatchers.get(name);
 
             if (d == null) {
@@ -468,12 +472,7 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
         // Hold lock throughout.
         sub.wLock();
         try {
-            String dname = opts.getDispatcherName();
-            Dispatcher d = this.messageDispatcher;
-
-            if (dname != null && !dname.isEmpty()) {
-                d = this.getCustomDispatcher(dname);
-            }
+            Dispatcher d = this.getDispatcherByName(opts.getDispatcherName());
 
             // Listen for actual messages
             d.subscribe(sub.inbox);

--- a/src/main/java/io/nats/streaming/SubscriptionImpl.java
+++ b/src/main/java/io/nats/streaming/SubscriptionImpl.java
@@ -19,6 +19,7 @@ import static io.nats.streaming.NatsStreaming.ERR_UNSUB_REQ_TIMEOUT;
 import static io.nats.streaming.NatsStreaming.PFX;
 
 import io.nats.client.Connection;
+import io.nats.client.Dispatcher;
 import io.nats.streaming.protobuf.SubscriptionResponse;
 import io.nats.streaming.protobuf.UnsubscribeRequest;
 import java.io.IOException;
@@ -123,7 +124,9 @@ class SubscriptionImpl implements Subscription {
             if (sc == null) {
                 throw new IllegalStateException(NatsStreaming.ERR_BAD_SUBSCRIPTION);
             }
-            sc.messageDispatcher.unsubscribe(this.inbox);
+
+            Dispatcher d = sc.getDispatcherByName(this.getOptions().getDispatcherName());
+            d.unsubscribe(this.inbox);
 
             this.sc = null;
 

--- a/src/main/java/io/nats/streaming/SubscriptionImpl.java
+++ b/src/main/java/io/nats/streaming/SubscriptionImpl.java
@@ -123,7 +123,7 @@ class SubscriptionImpl implements Subscription {
             if (sc == null) {
                 throw new IllegalStateException(NatsStreaming.ERR_BAD_SUBSCRIPTION);
             }
-            sc.dispatcher.unsubscribe(this.inbox);
+            sc.messageDispatcher.unsubscribe(this.inbox);
 
             this.sc = null;
 

--- a/src/main/java/io/nats/streaming/SubscriptionOptions.java
+++ b/src/main/java/io/nats/streaming/SubscriptionOptions.java
@@ -206,7 +206,7 @@ public class SubscriptionOptions {
         result = 31 * result + (ackWait != null ? ackWait.hashCode() : 0);
         result = 31 * result + (startAt != null ? startAt.hashCode() : 0);
         result = 31 * result + (int) (startSequence ^ (startSequence >>> 32));
-        result = 31 * result + (startTime != null ? startTime.hashCode() : 0);
+        result = 31 * result + (startTime != null ? startTime.getNano() : 0);
         result = 31 * result + (dispatcher != null ? dispatcher.hashCode() : 0);
         result = 31 * result + (manualAcks ? 1 : 0);
         return result;

--- a/src/main/java/io/nats/streaming/SubscriptionOptions.java
+++ b/src/main/java/io/nats/streaming/SubscriptionOptions.java
@@ -55,6 +55,7 @@ public class SubscriptionOptions {
     // Option to do Manual Acks
     private final boolean manualAcks;
     private final Duration subscriptionTimeout;
+    private final String dispatcher;
 
     // Date startTimeAsDate;
 
@@ -67,6 +68,7 @@ public class SubscriptionOptions {
         this.startTime = builder.startTime;
         this.manualAcks = builder.manualAcks;
         this.subscriptionTimeout = builder.subscriptionTimeout;
+        this.dispatcher = builder.dispatcher;
     }
 
     /**
@@ -155,6 +157,18 @@ public class SubscriptionOptions {
         return manualAcks;
     }
 
+    /**
+     * Returns name of the dispatcher to use for this subscription. Can be null.
+     * If no dispatcher is provided in the options, a single dispatcher/thread is shared
+     * with other similarly configured subscriptions. By sharing dispatchers suscriptions
+     * can reduce the threads used in their application.
+     * 
+     * @return the dispatcher name for this subscription.
+     */
+    public String getDispatcherName() {
+        return dispatcher;
+    }
+
     @java.lang.Override
     public java.lang.String toString() {
         return "SubscriptionOptions{" +
@@ -181,6 +195,7 @@ public class SubscriptionOptions {
         if (durableName != null ? !durableName.equals(that.durableName) : that.durableName != null) return false;
         if (ackWait != null ? !ackWait.equals(that.ackWait) : that.ackWait != null) return false;
         if (startAt != that.startAt) return false;
+        if (dispatcher != that.dispatcher) return false;
         return startTime != null ? startTime.equals(that.startTime) : that.startTime == null;
     }
 
@@ -192,6 +207,7 @@ public class SubscriptionOptions {
         result = 31 * result + (startAt != null ? startAt.hashCode() : 0);
         result = 31 * result + (int) (startSequence ^ (startSequence >>> 32));
         result = 31 * result + (startTime != null ? startTime.hashCode() : 0);
+        result = 31 * result + (dispatcher != null ? dispatcher.hashCode() : 0);
         result = 31 * result + (manualAcks ? 1 : 0);
         return result;
     }
@@ -210,6 +226,7 @@ public class SubscriptionOptions {
         Instant startTime;
         boolean manualAcks;
         Date startTimeAsDate;
+        String dispatcher;
         Duration subscriptionTimeout = SubscriptionOptions.DEFAULT_SUBSCRIPTION_TIMEOUT;
 
         /**
@@ -351,6 +368,21 @@ public class SubscriptionOptions {
          */
         public Builder deliverAllAvailable() {
             this.startAt = StartPosition.First;
+            return this;
+        }
+
+        /**
+         * Specify a dispatcher for this subscription. Dispatchers are essentially a message queue
+         * and thread to handle callbacks. By sharing dispatchers an application can reduce thread resources.
+         * By splitting subscriptions between dispatchers it is possible to have multiple messages handled
+         * at the same time.
+         * 
+         * A unique dispatcher will be created automatically for each name. Reusing the name reuses the dispatcher.
+         * 
+         * @return this
+         */
+        public Builder dispatcher(String dispatcherName) {
+            this.dispatcher = dispatcherName;
             return this;
         }
 

--- a/src/test/java/io/nats/streaming/NatsStreamingTestServer.java
+++ b/src/test/java/io/nats/streaming/NatsStreamingTestServer.java
@@ -68,6 +68,14 @@ class NatsStreamingTestServer implements AutoCloseable {
         start();
     }
 
+    public NatsStreamingTestServer(String clusterId, String[] customArgs, boolean debug) {
+        this.port = NatsStreamingTestServer.nextPort();
+        this.clusterId = clusterId;
+        this.debug = debug;
+        this.customArgs = customArgs;
+        start();
+    }
+
     public static int nextPort() {
         return NatsStreamingTestServer.portCounter.incrementAndGet();
     }

--- a/src/test/java/io/nats/streaming/PubSubTests.java
+++ b/src/test/java/io/nats/streaming/PubSubTests.java
@@ -160,17 +160,23 @@ public class PubSubTests {
                 // Test that we can't Ack if not in manual mode.
                 try (Subscription sub = sc.subscribe("foo", msg -> {
                     boolean exThrown = false;
+
                     try {
                         msg.ack();
                     } catch (Exception e) {
-                        assertEquals(StreamingConnectionImpl.ERR_MANUAL_ACK, e.getMessage());
+
+                        // first time ack should definitely be err for manual
+                        // after that we are in a quasi closed state and may get invalid sub
+                        if (fch.getCount() > 0) {
+                            assertEquals(StreamingConnectionImpl.ERR_MANUAL_ACK, e.getMessage());
+                        }
                         exThrown = true;
                     }
                     assertTrue("Expected manual ack exception", exThrown);
                     fch.countDown();
                 }, new SubscriptionOptions.Builder().deliverAllAvailable().build())) {
 
-                    assertTrue("Did not receive our first message", fch.await(5, TimeUnit.SECONDS));
+                    assertTrue("Did not receive our first message", fch.await(15, TimeUnit.SECONDS));
 
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -185,7 +191,6 @@ public class PubSubTests {
                 final List<Message> msgs = new CopyOnWriteArrayList<>();
 
                 assertTrue(sc.getNatsConnection().getStatus() == Status.CONNECTED);
-                assertTrue(((StreamingConnectionImpl)sc).messageDispatcher.isActive());
 
                 // Test we only receive MaxInflight if we do not ack
                 try (Subscription sub = sc.subscribe("foo", msg -> {

--- a/src/test/java/io/nats/streaming/PubSubTests.java
+++ b/src/test/java/io/nats/streaming/PubSubTests.java
@@ -31,6 +31,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
+import io.nats.client.Connection.Status;
+
 public class PubSubTests {
     private static final String clusterName = "test-cluster";
     private static final String clientName = "me";
@@ -141,6 +143,8 @@ public class PubSubTests {
         try (NatsStreamingTestServer srv = new NatsStreamingTestServer(clusterName, false)) {
             Options options = new Options.Builder().natsUrl(srv.getURI()).build();
             try (StreamingConnection sc = NatsStreaming.connect(clusterName, clientName, options)) {
+                assertTrue(sc.getNatsConnection().getStatus() == Status.CONNECTED);
+                assertTrue(((StreamingConnectionImpl)sc).messageDispatcher.isActive());
 
                 final int toSend = 100;
                 byte[] hw = "Hello World".getBytes();
@@ -179,6 +183,9 @@ public class PubSubTests {
 
                 // Capture the messages that are delivered.
                 final List<Message> msgs = new CopyOnWriteArrayList<>();
+
+                assertTrue(sc.getNatsConnection().getStatus() == Status.CONNECTED);
+                assertTrue(((StreamingConnectionImpl)sc).messageDispatcher.isActive());
 
                 // Test we only receive MaxInflight if we do not ack
                 try (Subscription sub = sc.subscribe("foo", msg -> {

--- a/src/test/java/io/nats/streaming/SubscribeTests.java
+++ b/src/test/java/io/nats/streaming/SubscribeTests.java
@@ -799,6 +799,7 @@ public class SubscribeTests {
                         latch.await(5, TimeUnit.SECONDS));
                 assertEquals("should get first message", 0, received.get());
 
+                try {Thread.sleep(2000);} catch(Exception e) {}; // get the ack in the queue
                 sub.close(); // Should not unsub
                 sc.getNatsConnection().flush(Duration.ofSeconds(2));
                 try {Thread.sleep(2000);} catch(Exception e) {}; // Give the server time to clean up
@@ -824,6 +825,7 @@ public class SubscribeTests {
                         latch2.await(5, TimeUnit.SECONDS));
                 assertEquals("should get second message", 1, received.get());
 
+                try {Thread.sleep(2000);} catch(Exception e) {}; // get the ack in the queue
                 sub2.close(true); // Should unsub
                 sc.getNatsConnection().flush(Duration.ofSeconds(2));
                 try {Thread.sleep(2000);} catch(Exception e) {}; // Give the server time to clean up

--- a/src/test/java/io/nats/streaming/SubscribeTests.java
+++ b/src/test/java/io/nats/streaming/SubscribeTests.java
@@ -798,7 +798,7 @@ public class SubscribeTests {
 
                 assertTrue("Did not receive first delivery of all messages",
                         latch.await(5, TimeUnit.SECONDS));
-                assertEquals("should get first message", received.get(), 0);
+                assertEquals("should get first message", 0, received.get());
 
                 sub.close(); // Should not unsub
                 sc.getNatsConnection().flush(Duration.ofSeconds(2));
@@ -823,7 +823,7 @@ public class SubscribeTests {
 
                 assertTrue("Did not receive first delivery of all messages",
                         latch2.await(5, TimeUnit.SECONDS));
-                assertEquals("should get second message", received.get(), 1);
+                assertEquals("should get second message", 1, received.get());
 
                 sub2.close(true); // Should unsub
                 sc.getNatsConnection().flush(Duration.ofSeconds(2));

--- a/src/test/java/io/nats/streaming/SubscriptionOptionsTest.java
+++ b/src/test/java/io/nats/streaming/SubscriptionOptionsTest.java
@@ -218,5 +218,11 @@ public class SubscriptionOptionsTest {
         assertEquals(opts.hashCode(), copy.hashCode());
         assertEquals(opts, copy);
         assertNotNull(opts.toString());
+        
+        opts = new SubscriptionOptions.Builder().dispatcher("one").build();
+        copy = new SubscriptionOptions.Builder().dispatcher("one").build();
+        assertEquals(opts.hashCode(), copy.hashCode());
+        assertEquals(opts, copy);
+        assertNotNull(opts.toString());
     }
 }

--- a/src/test/java/io/nats/streaming/SubscriptionOptionsTest.java
+++ b/src/test/java/io/nats/streaming/SubscriptionOptionsTest.java
@@ -214,11 +214,14 @@ public class SubscriptionOptionsTest {
         assertEquals(opts, copy);
         assertNotNull(opts.toString());
         
+        /*
+         * The values depend on Instant.now, so can't be run reliably. Also, the comparison is the same as startAtTime.
         opts = new SubscriptionOptions.Builder().startAtTimeDelta(Duration.ofMinutes(1)).build();
         copy = new SubscriptionOptions.Builder().startAtTimeDelta(Duration.ofMinutes(1)).build();
         assertEquals(opts.hashCode(), copy.hashCode());
         assertEquals(opts, copy);
         assertNotNull(opts.toString());
+        */
         
         opts = new SubscriptionOptions.Builder().dispatcher("one").build();
         copy = new SubscriptionOptions.Builder().dispatcher("one").build();

--- a/src/test/java/io/nats/streaming/SubscriptionOptionsTest.java
+++ b/src/test/java/io/nats/streaming/SubscriptionOptionsTest.java
@@ -207,8 +207,9 @@ public class SubscriptionOptionsTest {
         assertEquals(opts, copy);
         assertNotNull(opts.toString());
         
-        opts = new SubscriptionOptions.Builder().startAtTime(Instant.now()).build();
-        copy = new SubscriptionOptions.Builder().startAtTime(Instant.now()).build();
+        Instant now = Instant.now();
+        opts = new SubscriptionOptions.Builder().startAtTime(now).build();
+        copy = new SubscriptionOptions.Builder().startAtTime(now).build();
         assertEquals(opts.hashCode(), copy.hashCode());
         assertEquals(opts, copy);
         assertNotNull(opts.toString());


### PR DESCRIPTION
[Added] Added named dispatchers to subscriptions to allow application control of callback threads
[#100] Split internal callback dispatchers to prevent application code blocking heartbeats